### PR TITLE
added a check if SCL is in a HIGH state before SDA transition to a HIGH state

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -244,6 +244,9 @@ void i2c_int_tmr0(void) __interrupt(INT_NO_TMR0) __using(0) {
       SCL_DIR &= ~SCL_MASK;  // input, SCL: High
       break;
     case 12:                 // STOP Condition
+      if (!SCL_BIT) {
+        return;
+      }
       SDA_DIR &= ~SDA_MASK;  // input, SDA: High
       break;
     case 13:


### PR DESCRIPTION
In stop condition, we have to ensure that SCL has transitions to a HIGH state before SDA transitions to a HIGH state.